### PR TITLE
Changed Lexibank reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ changed by passing a different directory to each command using the `--output=pat
 ### Loading the Data
 
 CLICS data can be loaded from lexibank datasets, i.e. from lexical datasets following the 
-[conventions of the lexibank project](https://github.com/lexibank/lexibank/wiki). In particular,
+[conventions of the lexibank project](https://github.com/lexibank/lexibank#the-lexibank-dataset-format). In particular,
 lexibank datasets can be installed similar to python packages, using a command like
 
 ```shell

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     zip_safe=False,
     python_requires='>=3.5',
     install_requires=[
+        'attrs>=18.1',
         'pylexibank>=0.7,<0.10',
         'pyconcepticon',
         'pyglottolog',


### PR DESCRIPTION
The README link was pointing to the blank lexibank wiki - I think we probably want this one instead?